### PR TITLE
Add support for CosmosDB virtual network rules and AKS RBAC.

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -205,6 +205,26 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 				Set: resourceAzureRMCosmosDBAccountCapabilitiesHash,
 			},
 
+			"is_virtual_network_filter_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"virtual_network_rules": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash,
+			},
+
 			//computed
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -275,6 +295,7 @@ func resourceArmCosmosDBAccountCreate(d *schema.ResourceData, meta interface{}) 
 	kind := d.Get("kind").(string)
 	offerType := d.Get("offer_type").(string)
 	ipRangeFilter := d.Get("ip_range_filter").(string)
+	isVirtualNetworkFilterEnabled := d.Get("is_virtual_network_filter_enabled").(bool)
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 
 	r, err := client.CheckNameExists(ctx, name)
@@ -306,12 +327,14 @@ func resourceArmCosmosDBAccountCreate(d *schema.ResourceData, meta interface{}) 
 		Location: utils.String(location),
 		Kind:     documentdb.DatabaseAccountKind(kind),
 		DatabaseAccountCreateUpdateProperties: &documentdb.DatabaseAccountCreateUpdateProperties{
-			DatabaseAccountOfferType: utils.String(offerType),
-			IPRangeFilter:            utils.String(ipRangeFilter),
-			EnableAutomaticFailover:  utils.Bool(enableAutomaticFailover),
-			ConsistencyPolicy:        expandAzureRmCosmosDBAccountConsistencyPolicy(d),
-			Locations:                &geoLocations,
-			Capabilities:             expandAzureRmCosmosDBAccountCapabilities(d),
+			DatabaseAccountOfferType:      utils.String(offerType),
+			IPRangeFilter:                 utils.String(ipRangeFilter),
+			IsVirtualNetworkFilterEnabled: utils.Bool(isVirtualNetworkFilterEnabled),
+			EnableAutomaticFailover:       utils.Bool(enableAutomaticFailover),
+			ConsistencyPolicy:             expandAzureRmCosmosDBAccountConsistencyPolicy(d),
+			Locations:                     &geoLocations,
+			Capabilities:                  expandAzureRmCosmosDBAccountCapabilities(d),
+			VirtualNetworkRules:           expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
 		},
 		Tags: expandTags(tags),
 	}
@@ -345,6 +368,7 @@ func resourceArmCosmosDBAccountUpdate(d *schema.ResourceData, meta interface{}) 
 	kind := d.Get("kind").(string)
 	offerType := d.Get("offer_type").(string)
 	ipRangeFilter := d.Get("ip_range_filter").(string)
+	isVirtualNetworkFilterEnabled := d.Get("is_virtual_network_filter_enabled").(bool)
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 
 	//hacky, todo fix up once deprecated field 'failover_policy' is removed
@@ -390,12 +414,14 @@ func resourceArmCosmosDBAccountUpdate(d *schema.ResourceData, meta interface{}) 
 		Location: utils.String(location),
 		Kind:     documentdb.DatabaseAccountKind(kind),
 		DatabaseAccountCreateUpdateProperties: &documentdb.DatabaseAccountCreateUpdateProperties{
-			DatabaseAccountOfferType: utils.String(offerType),
-			IPRangeFilter:            utils.String(ipRangeFilter),
-			EnableAutomaticFailover:  utils.Bool(enableAutomaticFailover),
-			Capabilities:             expandAzureRmCosmosDBAccountCapabilities(d),
-			ConsistencyPolicy:        expandAzureRmCosmosDBAccountConsistencyPolicy(d),
-			Locations:                &oldLocations,
+			DatabaseAccountOfferType:      utils.String(offerType),
+			IPRangeFilter:                 utils.String(ipRangeFilter),
+			IsVirtualNetworkFilterEnabled: utils.Bool(isVirtualNetworkFilterEnabled),
+			EnableAutomaticFailover:       utils.Bool(enableAutomaticFailover),
+			Capabilities:                  expandAzureRmCosmosDBAccountCapabilities(d),
+			ConsistencyPolicy:             expandAzureRmCosmosDBAccountConsistencyPolicy(d),
+			Locations:                     &oldLocations,
+			VirtualNetworkRules:           expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
 		},
 		Tags: expandTags(tags),
 	}
@@ -493,6 +519,10 @@ func resourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("ip_range_filter", resp.IPRangeFilter)
 	d.Set("endpoint", resp.DocumentEndpoint)
 
+	if v := resp.IsVirtualNetworkFilterEnabled; v != nil {
+		d.Set("is_virtual_network_filter_enabled", resp.IsVirtualNetworkFilterEnabled)
+	}
+
 	if v := resp.EnableAutomaticFailover; v != nil {
 		d.Set("enable_automatic_failover", resp.EnableAutomaticFailover)
 	}
@@ -513,6 +543,10 @@ func resourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) er
 
 	if err := d.Set("capabilities", flattenAzureRmCosmosDBAccountCapabilities(resp.Capabilities)); err != nil {
 		return fmt.Errorf("Error setting `capabilities`: %+v", err)
+	}
+
+	if err := d.Set("virtual_network_rules", flattenAzureRmCosmosDBAccountVirtualNetworkRules(resp.VirtualNetworkRules)); err != nil {
+		return fmt.Errorf("Error setting `virtual_network_rules`: %+v", err)
 	}
 
 	if p := resp.ReadLocations; p != nil {
@@ -790,6 +824,17 @@ func expandAzureRmCosmosDBAccountCapabilities(d *schema.ResourceData) *[]documen
 	return &s
 }
 
+func expandAzureRmCosmosDBAccountVirtualNetworkRules(d *schema.ResourceData) *[]documentdb.VirtualNetworkRule {
+	virtualNetworkRules := d.Get("virtual_network_rules").(*schema.Set).List()
+
+	s := make([]documentdb.VirtualNetworkRule, len(virtualNetworkRules))
+	for i, r := range virtualNetworkRules {
+		m := r.(map[string]interface{})
+		s[i] = documentdb.VirtualNetworkRule{ID: utils.String(m["id"].(string))}
+	}
+	return &s
+}
+
 func flattenAzureRmCosmosDBAccountConsistencyPolicy(policy *documentdb.ConsistencyPolicy) []interface{} {
 
 	result := map[string]interface{}{}
@@ -873,6 +918,21 @@ func flattenAzureRmCosmosDBAccountCapabilities(capabilities *[]documentdb.Capabi
 	return &s
 }
 
+func flattenAzureRmCosmosDBAccountVirtualNetworkRules(rules *[]documentdb.VirtualNetworkRule) *schema.Set {
+	results := schema.Set{
+		F: resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash,
+	}
+
+	for _, r := range *rules {
+		rule := map[string]interface{}{
+			"id": *r.ID,
+		}
+		results.Add(rule)
+	}
+
+	return &results
+}
+
 //todo remove once deprecated field `failover_policy` is removed
 func resourceAzureRMCosmosDBAccountFailoverPolicyHash(v interface{}) int {
 	var buf bytes.Buffer
@@ -909,6 +969,16 @@ func resourceAzureRMCosmosDBAccountCapabilitiesHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if m, ok := v.(map[string]interface{}); ok {
+		buf.WriteString(m["id"].(string))
 	}
 
 	return hashcode.String(buf.String())

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -92,6 +92,12 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"enable_rbac": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"node_resource_group": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -379,6 +385,7 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	dnsPrefix := d.Get("dns_prefix").(string)
+	enableRBAC := d.Get("enable_rbac").(bool)
 	kubernetesVersion := d.Get("kubernetes_version").(string)
 
 	linuxProfile := expandAzureRmKubernetesClusterLinuxProfile(d)
@@ -408,6 +415,7 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 			AddonProfiles:           addonProfiles,
 			AgentPoolProfiles:       &agentProfiles,
 			DNSPrefix:               &dnsPrefix,
+			EnableRBAC:              &enableRBAC,
 			KubernetesVersion:       &kubernetesVersion,
 			LinuxProfile:            &linuxProfile,
 			ServicePrincipalProfile: servicePrincipalProfile,
@@ -476,6 +484,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 
 	if props := resp.ManagedClusterProperties; props != nil {
 		d.Set("dns_prefix", props.DNSPrefix)
+		d.Set("enable_rbac", props.EnableRBAC)
 		d.Set("fqdn", props.Fqdn)
 		d.Set("kubernetes_version", props.KubernetesVersion)
 		d.Set("node_resource_group", props.NodeResourceGroup)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -95,7 +95,8 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			"enable_rbac": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				ForceNew: true,
+				Default:  true,
 			},
 
 			"node_resource_group": {
@@ -517,7 +518,6 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 
 	kubeConfigRaw, kubeConfig := flattenAzureRmKubernetesClusterAccessProfile(&profile)
 	d.Set("kube_config_raw", kubeConfigRaw)
-
 	if err := d.Set("kube_config", kubeConfig); err != nil {
 		return fmt.Errorf("Error setting `kube_config`: %+v", err)
 	}

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -186,6 +186,8 @@ The following arguments are supported:
 
 * `service_principal` - (Required) A Service Principal block as documented below.
 
+* `enable_rbac` - (Optional) True or False. Enables or Disables Kubernetes Role Based Access Control (RBAC). Defaults to True. Changing this forces a new resource to be created.
+
 ---
 
 * `addon_profile` - (Optional) A `addon_profile` block.
@@ -300,6 +302,8 @@ The following attributes are exported:
 * `fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
 
 * `node_resource_group` - Auto-generated Resource Group containing AKS Cluster resources.
+
+* `enable_rbac` - Whether Role Based Access Control is currently enabled.
 
 * `kube_config_raw` - Raw Kubernetes config to be used by
     [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and


### PR DESCRIPTION
Just what it says on the tin.

Concretely, the former involves adding two properties to `azurerm_cosmosdb_account`--`is_virtual_network_filter_enabled` and `virtual_network_rules`--that correspond to the similarly-named REST API parameters. The latter involves adding a single boolean property, `enable_rbac`, to `azurerm_kubernetes_cluster`, that also corresponds to a similarly-named REST API parameter. 